### PR TITLE
setup.py license value fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from subprocess import check_output
 import os
 import sys
 
@@ -15,13 +16,12 @@ install_requires = ["scipy", "numpy", "natsort", "cython", "pysam", "pandas"]
 compile_options = [
     "-Ofast", "-Wall"
     # , "-stdlib=libc++"
-]  #, "-frename-registers", "-funroll-loops"] # , "-lgzstream", "-lz"
+]  # , "-frename-registers", "-funroll-loops"] # , "-lgzstream", "-lz"
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 lib_dirs = []
 include_dirs = [dir_path + "/bamread/src", dir_path]
 
-from subprocess import check_output
 
 # conda_path = check_output("which conda", shell=True).decode().strip()
 # conda_include = []
@@ -55,7 +55,7 @@ setup(
     author="Endre Bakken Stovner",
     author_email="endrebak85@gmail.com",
     url="http://github.com/endrebak/bamread",
-    license=["MIT"],
+    license="MIT",
     install_requires=install_requires,
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
The downloading package fails because the license line is a list rather than a string. See the following error:

```
> pip install -e .
Obtaining file:///home/muhammedhasan/Projects/bamread
    ERROR: Command errored out with exit status 1:
     command: /home/muhammedhasan/Projects/bamread/venv/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/home/muhammedhasan/Projects/bamread/setup.py'"'"'; __file__='"'"'/home/muhammedhasan/Projects/bamread/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-fbx8z3bk
         cwd: /home/muhammedhasan/Projects/bamread/
    Complete output (26 lines):
    Compiling bamread/src/bamread.pyx because it depends on /home/muhammedhasan/Projects/bamread/venv/lib/python3.7/site-packages/Cython/Includes/libc/stdint.pxd.
    [1/1] Cythonizing bamread/src/bamread.pyx
    running egg_info
    creating /tmp/pip-pip-egg-info-fbx8z3bk/bamread.egg-info
    writing /tmp/pip-pip-egg-info-fbx8z3bk/bamread.egg-info/PKG-INFO
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/home/muhammedhasan/Projects/bamread/setup.py", line 71, in <module>
        long_description=open("README.md").read())
      File "/home/muhammedhasan/anaconda3/lib/python3.7/distutils/core.py", line 148, in setup
        dist.run_commands()
      File "/home/muhammedhasan/anaconda3/lib/python3.7/distutils/dist.py", line 966, in run_commands
        self.run_command(cmd)
      File "/home/muhammedhasan/anaconda3/lib/python3.7/distutils/dist.py", line 985, in run_command
        cmd_obj.run()
      File "/home/muhammedhasan/Projects/bamread/venv/lib/python3.7/site-packages/setuptools/command/egg_info.py", line 292, in run
        writer(self, ep.name, os.path.join(self.egg_info, ep.name))
      File "/home/muhammedhasan/Projects/bamread/venv/lib/python3.7/site-packages/setuptools/command/egg_info.py", line 635, in write_pkg_info
        metadata.write_pkg_info(cmd.egg_info)
      File "/home/muhammedhasan/anaconda3/lib/python3.7/distutils/dist.py", line 1117, in write_pkg_info
        self.write_pkg_file(pkg_info)
      File "/home/muhammedhasan/Projects/bamread/venv/lib/python3.7/site-packages/setuptools/dist.py", line 185, in write_pkg_file
        license = rfc822_escape(self.get_license())
      File "/home/muhammedhasan/anaconda3/lib/python3.7/distutils/util.py", line 459, in rfc822_escape
        lines = header.split('\n')
    AttributeError: 'list' object has no attribute 'split'
```